### PR TITLE
Allow new users to predict in Phase limited groups

### DIFF
--- a/src/hooks/useGetUserGroupsData.js
+++ b/src/hooks/useGetUserGroupsData.js
@@ -5,6 +5,7 @@ import useCleanupController from "./useCleanupController";
 export const useGetUserGroupsData = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [userGroupList, setUserGroupList] = useState([]);
+  const [isNew, setIsNew] = useState(false);
   const [selectedUserGroup, setSelectedUserGroup] = useState(null);
   const [signal, cleanup, handleCancel] = useCleanupController();
 
@@ -13,6 +14,7 @@ export const useGetUserGroupsData = () => {
     getGroupData(group.name, signal)
       .then((res) => {
         setSelectedUserGroup(res.data.groupData);
+        res.data && setIsNew(res.data.isNew);
       })
       .catch((err) => handleCancel(err));
   };
@@ -37,5 +39,6 @@ export const useGetUserGroupsData = () => {
     selectedUserGroup,
     handleGroupSelect,
     isLoadingUserGroupsData: isLoading,
+    isNew,
   };
 };

--- a/src/pages/Predictions/PredictionForm/PredictionForm.jsx
+++ b/src/pages/Predictions/PredictionForm/PredictionForm.jsx
@@ -35,7 +35,7 @@ import {
 } from "../../../common/common.styles";
 
 export default function PredictionForm({ fixture, hasChangedGroup }) {
-  const { selectedUserGroup, mode } = useOutletContext();
+  const { selectedUserGroup, mode, isNew } = useOutletContext();
   const resultsMode = mode === "results";
   const [signal, cleanup, handleCancel] = useCleanupController();
   const [isLoading, setIsLoading] = useState(hasChangedGroup || false);
@@ -138,7 +138,8 @@ export default function PredictionForm({ fixture, hasChangedGroup }) {
               const canPredict = calculateIfCanPredict(
                 match.date,
                 selectedUserGroup,
-                phase
+                phase,
+                isNew
               );
 
               const renderInfoIcon = () => {

--- a/src/pages/Predictions/PredictionsPage.jsx
+++ b/src/pages/Predictions/PredictionsPage.jsx
@@ -19,6 +19,7 @@ function PredictionsPage() {
     userGroupList,
     selectedUserGroup,
     handleGroupSelect,
+    isNew,
   } = useGetUserGroupsData();
 
   const { t } = useTranslation();
@@ -72,7 +73,7 @@ function PredictionsPage() {
             </Info>
           )}
           <ToggleSwitch mode={mode} setMode={setMode} modes={predictionModes} />
-          <Outlet context={{ mode, selectedUserGroup, setMode }} />
+          <Outlet context={{ mode, selectedUserGroup, setMode, isNew }} />
         </>
       )}
     </PredictionsPageWrapper>

--- a/src/pages/Predictions/predictionsPageUtils.js
+++ b/src/pages/Predictions/predictionsPageUtils.js
@@ -145,11 +145,16 @@ export const checkPredictionResult = (
   return "tomato";
 };
 
-export const calculateIfCanPredict = (matchDate, selectedUserGroup, phase) => {
+export const calculateIfCanPredict = (
+  matchDate,
+  selectedUserGroup,
+  phase,
+  isNew
+) => {
   const now = Date.now();
   const timeLimit = parseInt(selectedUserGroup.rules.timeLimit, 10) || 0;
 
-  if (selectedUserGroup.rules.limitByPhase && phase === "groups") {
+  if (selectedUserGroup.rules.limitByPhase && phase === "groups" && !isNew) {
     const groupPhaseStart = new Date("2022-11-20T16:00:00.000Z").getTime();
     return now + timeLimit < groupPhaseStart;
   }

--- a/src/pages/Predictions/predictionsPageUtils.js
+++ b/src/pages/Predictions/predictionsPageUtils.js
@@ -149,7 +149,7 @@ export const calculateIfCanPredict = (
   matchDate,
   selectedUserGroup,
   phase,
-  isNew
+  isNew // TODO -> Pass this from groupData request
 ) => {
   const now = Date.now();
   const timeLimit = parseInt(selectedUserGroup.rules.timeLimit, 10) || 0;

--- a/src/pages/Predictions/predictionsPageUtils.js
+++ b/src/pages/Predictions/predictionsPageUtils.js
@@ -149,7 +149,7 @@ export const calculateIfCanPredict = (
   matchDate,
   selectedUserGroup,
   phase,
-  isNew // TODO -> Pass this from groupData request
+  isNew
 ) => {
   const now = Date.now();
   const timeLimit = parseInt(selectedUserGroup.rules.timeLimit, 10) || 0;

--- a/src/pages/Scores/components/ScoresByGroup/components/Graphs.jsx
+++ b/src/pages/Scores/components/ScoresByGroup/components/Graphs.jsx
@@ -53,8 +53,6 @@ export default function Graphs({ predictions, groupData }) {
     info: null,
   });
 
-  console.log(fixture);
-
   useEffect(() => {
     if (predictions?.length < 1 || fixture?.length < 1 || !graph || !fixture)
       return;


### PR DESCRIPTION
Takes new value from backend and parse it when checking if user can predict.
Allow new user to predict for 24 hours